### PR TITLE
chore: Move stuff around and up the model to large-v2

### DIFF
--- a/src/python/convert.py
+++ b/src/python/convert.py
@@ -10,4 +10,5 @@ def convert():
         transcribed += whisper.transcribe(episode)
     if (transcribed > 0):
         database.recreate_fts_table()
+        database.vacuum()
     database.close()

--- a/src/python/database.py
+++ b/src/python/database.py
@@ -24,7 +24,6 @@ def recreate_fts_table():
         GROUP BY
             w.episode;
     ''')
-    cur.execute('VACUUM;')
     con.commit()
 
 def make_episode_row(episode, word_count):
@@ -51,6 +50,11 @@ def make_episode_row(episode, word_count):
         None, # live
         None # compilation
     )
+
+def vacuum():
+    cur = con.cursor()
+    cur.execute('VACUUM;')
+    cur = con.commit()
 
 def select_word_count(episode_num):
     cur = con.cursor()

--- a/src/python/utils.py
+++ b/src/python/utils.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import os
+from bs4 import BeautifulSoup
 
 def log(episode_num, *msg):
     print(f'-- {now()} -- Episode {episode_num} --', *msg)
@@ -30,3 +31,6 @@ def get_audio_url(episode):
 
 def get_image_url(episode):
     return episode['image']['href']
+
+def strip_html(htmlString):
+    return BeautifulSoup(htmlString, 'html.parser').get_text()

--- a/src/python/whisper.py
+++ b/src/python/whisper.py
@@ -1,13 +1,13 @@
 from faster_whisper import WhisperModel
-from bs4 import BeautifulSoup
 import database 
 import utils
 
-model_size = 'medium.en'
+model_size = 'large-v2'
 
 model = WhisperModel(
     model_size_or_path=model_size,
     compute_type='int8',
+    # Change this to False if you want to use/download a different model
     local_files_only=True,
     num_workers=4,
     cpu_threads=8
@@ -15,7 +15,7 @@ model = WhisperModel(
 
 def get_transcription_segments(episode):
     episode_num = utils.get_episode_num(episode)
-    summary = BeautifulSoup(episode['summary'], 'html.parser').get_text()
+    summary = utils.strip_html(episode['summary'])
     segments, _ = model.transcribe(
         utils.make_audio_file_path(episode_num),
         word_timestamps=True,


### PR DESCRIPTION
Where medium.en took ~40 minutes per hour of audio, large-v2 is basically 1x so an hour of audio takes an hour of transcription.

When doing episodes one at a time this is not as much of a big deal and will hopefully add a little more accuracy.