### PR TITLE
feat: Add episode type filter

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/src/js/App.tsx
+++ b/src/js/App.tsx
@@ -7,6 +7,7 @@ import { mediaUrl } from './utils';
 import { fadeIn } from './styleUtils';
 import { AudioContextWrapper } from './audio/AudioContext';
 import { Colors } from './constants';
+import { FiltersContextProvider } from './filters/FiltersContext';
 
 const Wrapper = styled.div`
   display: flex;
@@ -64,7 +65,9 @@ export const App = () => {
             <UnderConstructionBanner />
             <img className="nstaaf-logo" src={mediaUrl.images('logo.jpg')} />
             <ErrorBoundary FallbackComponent={EpisodeSearchFallback}>
-              <EpisodeSearch />
+              <FiltersContextProvider>
+                <EpisodeSearch />
+              </FiltersContextProvider>
             </ErrorBoundary>
           </div>
         </>

--- a/src/js/App.tsx
+++ b/src/js/App.tsx
@@ -4,7 +4,6 @@ import { EpisodeSearch } from './EpisodesSearch';
 import { UnderConstructionBanner } from './UnderConstructionBanner';
 import { EpisodeSearchFallback } from './EpisodeSearchFallback';
 import { mediaUrl } from './utils';
-import { fadeIn } from './styleUtils';
 import { AudioContextWrapper } from './audio/AudioContext';
 import { Colors } from './constants';
 import { FiltersContextProvider } from './filters/FiltersContext';
@@ -13,7 +12,6 @@ const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   line-height: 1.1;
-  ${fadeIn}
 
   & header {
     display: flex;

--- a/src/js/EpisodesSearch.tsx
+++ b/src/js/EpisodesSearch.tsx
@@ -9,20 +9,18 @@ import { EmptyState } from './EmptyState';
 import { SearchBar } from './SearchBar';
 import { Total } from './Total';
 import { preventDefault } from './utils';
-import { fadeIn } from './styleUtils';
-import { SearchFilters } from './filters/SearchFilters';
-import { PresenterFilters } from './filters/PresenterFilters';
-import { EpisodeTypeFilters } from './filters/EpisodeTypeFilters';
 import { FiltersContext } from './filters/FiltersContext';
 
 const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
-  ${fadeIn}
 `;
 
 export const EpisodeSearch = () => {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [page, setPage] = useState(0);
+
   const {
     episodes: {
       data: episodes,
@@ -39,18 +37,15 @@ export const EpisodeSearch = () => {
     episodeTypeFilters,
     presenterFilters,
     searchFilters,
-    handleSearchFilterToggle,
-    handleEpisodeTypeFilterToggle,
-    handlePresenterFilterChange,
   } = useContext(FiltersContext);
-
-  const [searchTerm, setSearchTerm] = useState('');
-  const [page, setPage] = useState(0);
 
   useEffect(() => {
     search(searchTerm, searchFilters);
-    setPage(0);
   }, [search, searchTerm, searchFilters]);
+
+  useEffect(() => {
+    setPage(0);
+  }, [episodeTypeFilters, presenterFilters, searchTerm, searchFilters]);
 
   const handleSubmit = useCallback((e: FormEvent) => {
     preventDefault(e);
@@ -80,20 +75,7 @@ export const EpisodeSearch = () => {
         placeholder="no such thing as a search bar"
         onSubmit={handleSubmit}
       />
-      <FilterBar>
-        <SearchFilters
-          selected={searchFilters}
-          onToggle={handleSearchFilterToggle}
-        />
-        <EpisodeTypeFilters
-          selected={episodeTypeFilters}
-          onToggle={handleEpisodeTypeFilterToggle}
-        />
-        <PresenterFilters
-          selected={presenterFilters}
-          onChange={handlePresenterFilterChange}
-        />
-      </FilterBar>
+      <FilterBar />
       {!!total && (
         <Total
           presenters={presentersFull}

--- a/src/js/EpisodesSearch.tsx
+++ b/src/js/EpisodesSearch.tsx
@@ -4,7 +4,7 @@ import { EpisodesTable } from './EpisodesTable';
 import { useDb } from './dbHooks';
 import { PAGE_SIZE } from './constants';
 import { PaginationSpacer, Paginator } from './Paginator';
-import { SearchFiltersState } from './types';
+import { EpisodeTypeFiltersState, SearchFiltersState } from './types';
 import { FilterBar } from './filters/FilterBar';
 import { EmptyState } from './EmptyState';
 import { SearchBar } from './SearchBar';
@@ -13,6 +13,7 @@ import { preventDefault } from './utils';
 import { fadeIn } from './styleUtils';
 import { SearchFilters } from './filters/SearchFilters';
 import { PresenterFilters } from './filters/PresenterFilters';
+import { EpisodeTypeFilters } from './filters/EpisodeTypeFilters';
 
 const Wrapper = styled.div`
   display: flex;
@@ -36,12 +37,30 @@ export const EpisodeSearch = () => {
   const [searchTerm, setSearchTerm] = useState('');
   const [page, setPage] = useState(0);
   const [presenterFilters, setPresenterFilters] = useState<number[]>([]);
+  const [episodeTypeFilters, setEpisodeTypeFilters] =
+    useState<EpisodeTypeFiltersState>({
+      live: true,
+      compilation: true,
+      wfh: true,
+      office: true,
+    });
+
   const [searchFilters, setSearchFilters] = useState<SearchFiltersState>({
     episode: true,
     title: true,
     description: true,
     words: true,
   });
+
+  const handleEpisodeTypeFilterToggle = useCallback(
+    ({ name, checked }: { name: string; checked: boolean }) => {
+      setEpisodeTypeFilters(current => ({
+        ...current,
+        [name]: checked,
+      }));
+    },
+    []
+  );
 
   const handleSearchFilterToggle = useCallback(
     ({ name, checked }: { name: string; checked: boolean }) => {
@@ -101,6 +120,10 @@ export const EpisodeSearch = () => {
         <SearchFilters
           selected={searchFilters}
           onToggle={handleSearchFilterToggle}
+        />
+        <EpisodeTypeFilters
+          selected={episodeTypeFilters}
+          onToggle={handleEpisodeTypeFilterToggle}
         />
         <PresenterFilters
           selected={presenterFilters}

--- a/src/js/EpisodesSearch.tsx
+++ b/src/js/EpisodesSearch.tsx
@@ -22,6 +22,13 @@ const Wrapper = styled.div`
   ${fadeIn}
 `;
 
+const WFH_VANUE_ID = 2;
+const QI_OFFICE_VENUE_IDS = [
+  1, // Covent Garden
+  4, // Hoburn
+  9, // 2020 Audio
+];
+
 export const EpisodeSearch = () => {
   const {
     episodes: {
@@ -91,19 +98,28 @@ export const EpisodeSearch = () => {
     return null;
   }
 
-  const filteredEpisodes =
-    presenterFilters.length === 0
-      ? episodes
-      : episodes.filter(epi => {
-          return (
-            presenterFilters.includes(epi.presenter1) ||
-            presenterFilters.includes(epi.presenter2) ||
-            presenterFilters.includes(epi.presenter3) ||
-            presenterFilters.includes(epi.presenter4) ||
-            presenterFilters.includes(epi.presenter5)
-          );
-        });
+  const filteredEpisodes = episodes
+    .filter(epi => {
+      if (presenterFilters.length === 0) {
+        return true;
+      }
 
+      return (
+        presenterFilters.includes(epi.presenter1) ||
+        presenterFilters.includes(epi.presenter2) ||
+        presenterFilters.includes(epi.presenter3) ||
+        presenterFilters.includes(epi.presenter4) ||
+        presenterFilters.includes(epi.presenter5)
+      );
+    })
+    .filter(epi => {
+      return (
+        (epi.live && episodeTypeFilters.live) ||
+        (epi.compilation && episodeTypeFilters.compilation) ||
+        (epi.venue === WFH_VANUE_ID && episodeTypeFilters.wfh) ||
+        (QI_OFFICE_VENUE_IDS.includes(epi.venue) && episodeTypeFilters.office)
+      );
+    });
   const totalPages = Math.ceil(filteredEpisodes.length / PAGE_SIZE);
   const episodesLength = episodesError ? 0 : filteredEpisodes.length;
   const presentersFull = presenters

--- a/src/js/EpisodesSearch.tsx
+++ b/src/js/EpisodesSearch.tsx
@@ -5,12 +5,14 @@ import { useDb } from './dbHooks';
 import { PAGE_SIZE } from './constants';
 import { PaginationSpacer, Paginator } from './Paginator';
 import { SearchFiltersState } from './types';
-import { FilterBar, PresenterFilters, SearchFilters } from './FilterBar';
+import { FilterBar } from './filters/FilterBar';
 import { EmptyState } from './EmptyState';
 import { SearchBar } from './SearchBar';
 import { Total } from './Total';
 import { preventDefault } from './utils';
 import { fadeIn } from './styleUtils';
+import { SearchFilters } from './filters/SearchFilters';
+import { PresenterFilters } from './filters/PresenterFilters';
 
 const Wrapper = styled.div`
   display: flex;

--- a/src/js/Tags.tsx
+++ b/src/js/Tags.tsx
@@ -1,5 +1,8 @@
 import { styled } from 'styled-components';
 import { Colors } from './constants';
+import { useContext } from 'react';
+import { FiltersContext } from './filters/FiltersContext';
+import { EpisodeType, EpisodeTypeFiltersState } from './types';
 
 export const TagWrapper = styled.div`
   display: flex;
@@ -7,9 +10,11 @@ export const TagWrapper = styled.div`
   justify-content: start;
 `;
 
-export const Tag = styled.span`
+export const Tag = styled.button.attrs({ className: 'text' })`
+  border: none;
   background: ${Colors.night};
   color: white;
+  cursor: pointer;
   padding: 0.3rem 0.5rem;
   margin-bottom: 0.8em;
   border-radius: 2px;
@@ -19,20 +24,35 @@ export const Tag = styled.span`
   }
 `;
 
-export const Tags = ({
-  live,
-  compilation,
-}: {
+interface TagsProps {
   live: number;
   compilation: number;
-}) => {
+}
+
+export const Tags = ({ live, compilation }: TagsProps) => {
+  const { setEpisodeTypeFilters } = useContext(FiltersContext);
   const isLive = !!live;
   const isComp = !!compilation;
+  const makeTagClickHandler = (property: EpisodeType) => () => {
+    setEpisodeTypeFilters(state => {
+      const rest = Object.entries(state).filter(([k]) => k !== property);
+      const restOn = (rest as [EpisodeType, boolean][]).some(([k]) => state[k]);
+      const restObj = Object.fromEntries(rest.map(([k]) => [k, !restOn]));
+
+      return {
+        [property]: true,
+        ...restObj,
+      } as EpisodeTypeFiltersState;
+    });
+  };
+
   return (
     (isLive || isComp) && (
       <TagWrapper>
-        {isLive && <Tag>Live</Tag>}
-        {isComp && <Tag>Compilation</Tag>}
+        {isLive && <Tag onClick={makeTagClickHandler('live')}>Live</Tag>}
+        {isComp && (
+          <Tag onClick={makeTagClickHandler('compilation')}>Compilation</Tag>
+        )}
       </TagWrapper>
     )
   );

--- a/src/js/Total.tsx
+++ b/src/js/Total.tsx
@@ -38,14 +38,15 @@ export const Total = ({
     const separator = i < list.length - 1 ? ', ' : ' or ';
     return `${i > 0 ? separator : ''}${formatName(p)}`;
   });
-  const containingText = searchTerm && <>episodes containing "{searchTerm}"</>;
+  const totalText = <>{total} episodes</>;
+  const containingText = searchTerm && <>containing "{searchTerm}"</>;
   const isShowingAll = results === total && !searchTerm;
   const foundResults = isShowingAll ? (
-    <>showing all {total} episodes</>
+    <>showing all {totalText}</>
   ) : (
     <>
       <>
-        found {error ? '?' : results} of {total} {containingText}
+        found {error ? '?' : results} of {totalText} {containingText}
       </>
       {presenters.length > 0 && <> with {presentersText} presenting</>}
     </>

--- a/src/js/filters/EpisodeTypeFilters.tsx
+++ b/src/js/filters/EpisodeTypeFilters.tsx
@@ -1,14 +1,14 @@
 import { useCallback } from 'react';
-import styled from 'styled-components';
+import { FilterSection } from './FilterSection';
 import {
-  SearchFilterLabels,
-  SearchField,
-  SearchFiltersProps,
+  EpisodeType,
+  EpisodeTypeFilterLabels,
+  EpisodeTypeFiltersProps,
   SelectedOption,
 } from '../types';
-import { FilterSection } from './FilterSection';
+import styled from 'styled-components';
 
-export const FilterWrapper = styled.div`
+export const Wrapper = styled.div`
   display: flex;
   flex-grow: 1;
   flex-wrap: wrap;
@@ -30,14 +30,17 @@ export const FilterWrapper = styled.div`
   }
 `;
 
-const filterLabels: SearchFilterLabels = {
-  description: 'description',
-  episode: 'episode number',
-  title: 'title',
-  words: 'transcript',
+const filterLabels: EpisodeTypeFilterLabels = {
+  live: 'live',
+  compilation: 'compilation',
+  wfh: 'wfh',
+  office: 'qi offices',
 };
 
-export const SearchFilters = ({ selected, onToggle }: SearchFiltersProps) => {
+export const EpisodeTypeFilters = ({
+  selected,
+  onToggle,
+}: EpisodeTypeFiltersProps) => {
   const handleToggle = useCallback(
     ({ target }: { target: SelectedOption }) => {
       onToggle(target);
@@ -45,20 +48,20 @@ export const SearchFilters = ({ selected, onToggle }: SearchFiltersProps) => {
     [onToggle]
   );
   return (
-    <FilterSection label="Search filters:">
-      <FilterWrapper>
-        {Object.entries(selected).map(([name, checked]) => (
+    <FilterSection label="Episode type filters:">
+      <Wrapper>
+        {Object.entries(filterLabels).map(([name, label]) => (
           <label key={name}>
             <input
               onChange={handleToggle}
               type="checkbox"
               name={name}
-              checked={checked}
+              checked={selected[name as EpisodeType]}
             />
-            {filterLabels[name as SearchField]}
+            {label}
           </label>
         ))}
-      </FilterWrapper>
+      </Wrapper>
     </FilterSection>
   );
 };

--- a/src/js/filters/EpisodeTypeFilters.tsx
+++ b/src/js/filters/EpisodeTypeFilters.tsx
@@ -1,12 +1,8 @@
-import { useCallback } from 'react';
+import { useCallback, useContext } from 'react';
 import { FilterSection } from './FilterSection';
-import {
-  EpisodeType,
-  EpisodeTypeFilterLabels,
-  EpisodeTypeFiltersProps,
-  SelectedOption,
-} from '../types';
+import { EpisodeType, EpisodeTypeFilterLabels, SelectedOption } from '../types';
 import styled from 'styled-components';
+import { FiltersContext } from './FiltersContext';
 
 export const Wrapper = styled.div`
   display: flex;
@@ -32,20 +28,20 @@ export const Wrapper = styled.div`
 
 const filterLabels: EpisodeTypeFilterLabels = {
   live: 'live',
-  compilation: 'compilation',
-  wfh: 'wfh',
   office: 'qi offices',
+  wfh: 'wfh',
+  compilation: 'compilation',
 };
 
-export const EpisodeTypeFilters = ({
-  selected,
-  onToggle,
-}: EpisodeTypeFiltersProps) => {
+export const EpisodeTypeFilters = () => {
+  const { episodeTypeFilters, handleEpisodeTypeFilterToggle } =
+    useContext(FiltersContext);
+
   const handleToggle = useCallback(
-    ({ target }: { target: SelectedOption }) => {
-      onToggle(target);
+    ({ target }: { target: SelectedOption<string> }) => {
+      handleEpisodeTypeFilterToggle(target as SelectedOption<EpisodeType>);
     },
-    [onToggle]
+    [handleEpisodeTypeFilterToggle]
   );
   return (
     <FilterSection label="Episode type filters:">
@@ -56,7 +52,7 @@ export const EpisodeTypeFilters = ({
               onChange={handleToggle}
               type="checkbox"
               name={name}
-              checked={selected[name as EpisodeType]}
+              checked={episodeTypeFilters[name as EpisodeType]}
             />
             {label}
           </label>

--- a/src/js/filters/FilterBar.tsx
+++ b/src/js/filters/FilterBar.tsx
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+
+export const FilterBar = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  flex-wrap: wrap;
+  margin: 1.8rem 3vw 0 0;
+
+  @media (max-width: 900px) {
+    margin: 1.8rem 4.5vw 0 0;
+  }
+
+  @media (max-width: 650px) {
+    margin: 1.8rem 6vw 0 0;
+  }
+
+  @media (max-width: 480px) {
+    flex-direction: column;
+    align-items: stretch;
+  }
+`;

--- a/src/js/filters/FilterBar.tsx
+++ b/src/js/filters/FilterBar.tsx
@@ -1,6 +1,9 @@
 import styled from 'styled-components';
+import { SearchFilters } from './SearchFilters';
+import { EpisodeTypeFilters } from './EpisodeTypeFilters';
+import { PresenterFilters } from './PresenterFilters';
 
-export const FilterBar = styled.div`
+const StyledWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: stretch;
@@ -20,3 +23,11 @@ export const FilterBar = styled.div`
     align-items: stretch;
   }
 `;
+
+export const FilterBar = () => (
+  <StyledWrapper>
+    <SearchFilters />
+    <EpisodeTypeFilters />
+    <PresenterFilters />
+  </StyledWrapper>
+);

--- a/src/js/filters/FilterSection.tsx
+++ b/src/js/filters/FilterSection.tsx
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import { bold } from '../styleUtils';
 import { ReactNode } from 'react';
 
 const FilterSectionWrapper = styled.div`
@@ -24,7 +23,6 @@ const FilterSectionWrapper = styled.div`
 
 const FilterSectionLabel = styled.span`
   margin: 0 1rem 0.6rem 0;
-  ${bold}
 `;
 
 export const FilterSection = ({

--- a/src/js/filters/FilterSection.tsx
+++ b/src/js/filters/FilterSection.tsx
@@ -1,0 +1,43 @@
+import styled from 'styled-components';
+import { bold } from '../styleUtils';
+import { ReactNode } from 'react';
+
+const FilterSectionWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  margin: 0 0 1.8rem 3vw;
+
+  @media (max-width: 900px) {
+    margin: 0 0 1.8rem 4.5vw;
+  }
+
+  @media (max-width: 650px) {
+    margin: 0 0 1.8rem 6vw;
+  }
+
+  @media (max-width: 420px) {
+    flex-direction: column;
+    align-items: stretch;
+  }
+`;
+
+const FilterSectionLabel = styled.span`
+  margin: 0 1rem 0.6rem 0;
+  ${bold}
+`;
+
+export const FilterSection = ({
+  label,
+  children,
+}: {
+  label: ReactNode;
+  children: ReactNode;
+}) => {
+  return (
+    <FilterSectionWrapper>
+      <FilterSectionLabel className="bold">{label}</FilterSectionLabel>
+      {children}
+    </FilterSectionWrapper>
+  );
+};

--- a/src/js/filters/FiltersContext.tsx
+++ b/src/js/filters/FiltersContext.tsx
@@ -1,9 +1,20 @@
-import { ReactElement, createContext, useCallback, useState } from 'react';
-import { Episode, EpisodeTypeFiltersState, SearchFiltersState } from '../types';
+import {
+  Dispatch,
+  ReactElement,
+  SetStateAction,
+  createContext,
+  useState,
+} from 'react';
+import {
+  Episode,
+  EpisodeType,
+  EpisodeTypeFiltersState,
+  SearchField,
+  SearchFiltersState,
+} from '../types';
 
 type PresenterFiltersState = number[];
-type FilterToggleHandler = (args: { name: string; checked: boolean }) => void;
-type PresenterFilterChangeHandlers = (selected: number[]) => void;
+type FilterToggleHandler<T> = (args: { name: T; checked: boolean }) => void;
 
 const WFH_VANUE_ID = 2;
 const QI_OFFICE_VENUE_IDS = [
@@ -37,9 +48,10 @@ export const FiltersContext = createContext<{
   episodeTypeFilters: EpisodeTypeFiltersState;
   searchFilters: SearchFiltersState;
   presenterFilters: PresenterFiltersState;
-  handleEpisodeTypeFilterToggle: FilterToggleHandler;
-  handleSearchFilterToggle: FilterToggleHandler;
-  handlePresenterFilterChange: PresenterFilterChangeHandlers;
+  handleEpisodeTypeFilterToggle: FilterToggleHandler<EpisodeType>;
+  handleSearchFilterToggle: FilterToggleHandler<SearchField>;
+  setPresenterFilters: Dispatch<SetStateAction<PresenterFiltersState>>;
+  setEpisodeTypeFilters: Dispatch<SetStateAction<EpisodeTypeFiltersState>>;
 }>({
   getFilteredEpisodes: () => undefined,
   episodeTypeFilters: defaultEpisodeTypeFiltersState,
@@ -47,7 +59,8 @@ export const FiltersContext = createContext<{
   presenterFilters: defaultPresenterFiltersState,
   handleEpisodeTypeFilterToggle: noop,
   handleSearchFilterToggle: noop,
-  handlePresenterFilterChange: noop,
+  setPresenterFilters: noop,
+  setEpisodeTypeFilters: n => n,
 });
 
 export const FiltersContextProvider = ({
@@ -65,47 +78,47 @@ export const FiltersContextProvider = ({
     defaultSearchFiltersState
   );
 
-  const handleEpisodeTypeFilterToggle: FilterToggleHandler = useCallback(
-    ({ name, checked }) => {
-      setEpisodeTypeFilters(current => ({
-        ...current,
-        [name]: checked,
-      }));
-    },
-    []
-  );
+  const handleEpisodeTypeFilterToggle: FilterToggleHandler<EpisodeType> = ({
+    name,
+    checked,
+  }) => {
+    setEpisodeTypeFilters(current => ({
+      ...current,
+      [name]: checked,
+    }));
+  };
 
-  const handleSearchFilterToggle: FilterToggleHandler = useCallback(
-    ({ name, checked }) => {
-      setSearchFilters(current => ({
-        ...current,
-        [name]: checked,
-      }));
-    },
-    []
-  );
+  const handleSearchFilterToggle: FilterToggleHandler<SearchField> = ({
+    name,
+    checked,
+  }) => {
+    setSearchFilters(current => ({
+      ...current,
+      [name]: checked,
+    }));
+  };
 
   const getFilteredEpisodes = (episodes: Episode[] = []) =>
     episodes
-      .filter(epi => {
+      .filter(ep => {
         if (presenterFilters.length === 0) {
           return true;
         }
 
         return (
-          presenterFilters.includes(epi.presenter1) ||
-          presenterFilters.includes(epi.presenter2) ||
-          presenterFilters.includes(epi.presenter3) ||
-          presenterFilters.includes(epi.presenter4) ||
-          presenterFilters.includes(epi.presenter5)
+          presenterFilters.includes(ep.presenter1) ||
+          presenterFilters.includes(ep.presenter2) ||
+          presenterFilters.includes(ep.presenter3) ||
+          presenterFilters.includes(ep.presenter4) ||
+          presenterFilters.includes(ep.presenter5)
         );
       })
-      .filter(epi => {
+      .filter(ep => {
         return (
-          (epi.live && episodeTypeFilters.live) ||
-          (epi.compilation && episodeTypeFilters.compilation) ||
-          (epi.venue === WFH_VANUE_ID && episodeTypeFilters.wfh) ||
-          (QI_OFFICE_VENUE_IDS.includes(epi.venue) && episodeTypeFilters.office)
+          (ep.live && episodeTypeFilters.live) ||
+          (ep.compilation && episodeTypeFilters.compilation) ||
+          (ep.venue === WFH_VANUE_ID && episodeTypeFilters.wfh) ||
+          (QI_OFFICE_VENUE_IDS.includes(ep.venue) && episodeTypeFilters.office)
         );
       });
 
@@ -118,7 +131,8 @@ export const FiltersContextProvider = ({
         presenterFilters,
         handleEpisodeTypeFilterToggle,
         handleSearchFilterToggle,
-        handlePresenterFilterChange: setPresenterFilters,
+        setPresenterFilters,
+        setEpisodeTypeFilters,
       }}
     >
       {children}

--- a/src/js/filters/FiltersContext.tsx
+++ b/src/js/filters/FiltersContext.tsx
@@ -1,0 +1,127 @@
+import { ReactElement, createContext, useCallback, useState } from 'react';
+import { Episode, EpisodeTypeFiltersState, SearchFiltersState } from '../types';
+
+type PresenterFiltersState = number[];
+type FilterToggleHandler = (args: { name: string; checked: boolean }) => void;
+type PresenterFilterChangeHandlers = (selected: number[]) => void;
+
+const WFH_VANUE_ID = 2;
+const QI_OFFICE_VENUE_IDS = [
+  1, // Covent Garden
+  4, // Hoburn
+  9, // 2020 Audio
+];
+
+const defaultEpisodeTypeFiltersState = {
+  live: true,
+  compilation: true,
+  wfh: true,
+  office: true,
+};
+
+const defaultSearchFiltersState = {
+  episode: true,
+  title: true,
+  description: true,
+  words: true,
+};
+
+const defaultPresenterFiltersState: PresenterFiltersState = [];
+
+const noop = () => {
+  return undefined;
+};
+
+export const FiltersContext = createContext<{
+  getFilteredEpisodes: (episodes?: Episode[]) => Episode[] | undefined;
+  episodeTypeFilters: EpisodeTypeFiltersState;
+  searchFilters: SearchFiltersState;
+  presenterFilters: PresenterFiltersState;
+  handleEpisodeTypeFilterToggle: FilterToggleHandler;
+  handleSearchFilterToggle: FilterToggleHandler;
+  handlePresenterFilterChange: PresenterFilterChangeHandlers;
+}>({
+  getFilteredEpisodes: () => undefined,
+  episodeTypeFilters: defaultEpisodeTypeFiltersState,
+  searchFilters: defaultSearchFiltersState,
+  presenterFilters: defaultPresenterFiltersState,
+  handleEpisodeTypeFilterToggle: noop,
+  handleSearchFilterToggle: noop,
+  handlePresenterFilterChange: noop,
+});
+
+export const FiltersContextProvider = ({
+  children,
+}: {
+  children: ReactElement;
+}) => {
+  const [presenterFilters, setPresenterFilters] =
+    useState<PresenterFiltersState>([]);
+
+  const [episodeTypeFilters, setEpisodeTypeFilters] =
+    useState<EpisodeTypeFiltersState>(defaultEpisodeTypeFiltersState);
+
+  const [searchFilters, setSearchFilters] = useState<SearchFiltersState>(
+    defaultSearchFiltersState
+  );
+
+  const handleEpisodeTypeFilterToggle: FilterToggleHandler = useCallback(
+    ({ name, checked }) => {
+      setEpisodeTypeFilters(current => ({
+        ...current,
+        [name]: checked,
+      }));
+    },
+    []
+  );
+
+  const handleSearchFilterToggle: FilterToggleHandler = useCallback(
+    ({ name, checked }) => {
+      setSearchFilters(current => ({
+        ...current,
+        [name]: checked,
+      }));
+    },
+    []
+  );
+
+  const getFilteredEpisodes = (episodes: Episode[] = []) =>
+    episodes
+      .filter(epi => {
+        if (presenterFilters.length === 0) {
+          return true;
+        }
+
+        return (
+          presenterFilters.includes(epi.presenter1) ||
+          presenterFilters.includes(epi.presenter2) ||
+          presenterFilters.includes(epi.presenter3) ||
+          presenterFilters.includes(epi.presenter4) ||
+          presenterFilters.includes(epi.presenter5)
+        );
+      })
+      .filter(epi => {
+        return (
+          (epi.live && episodeTypeFilters.live) ||
+          (epi.compilation && episodeTypeFilters.compilation) ||
+          (epi.venue === WFH_VANUE_ID && episodeTypeFilters.wfh) ||
+          (QI_OFFICE_VENUE_IDS.includes(epi.venue) && episodeTypeFilters.office)
+        );
+      });
+
+  return (
+    <FiltersContext.Provider
+      value={{
+        getFilteredEpisodes,
+        episodeTypeFilters,
+        searchFilters,
+        presenterFilters,
+        handleEpisodeTypeFilterToggle,
+        handleSearchFilterToggle,
+        handlePresenterFilterChange: setPresenterFilters,
+      }}
+    >
+      {children}
+    </FiltersContext.Provider>
+  );
+};

--- a/src/js/filters/PresenterFilters.tsx
+++ b/src/js/filters/PresenterFilters.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useContext, useMemo } from 'react';
 import Select, { MultiValue, Theme, StylesConfig } from 'react-select';
-import { Option, Presenter, PresenterFiltersProps } from '../types';
+import { Option, Presenter } from '../types';
 import { useDb } from '../dbHooks';
 import { formatName } from '../utils';
 import { Colors, hosts } from '../constants';
 import { FilterSection } from './FilterSection';
+import { FiltersContext } from './FiltersContext';
 
 const noOneFound = () => 'No one found';
 
@@ -51,16 +52,18 @@ const groupLabels: Record<PresenterType, string> = {
   guest: 'Guests',
 };
 
-export const PresenterFilters = ({ onChange }: PresenterFiltersProps) => {
+export const PresenterFilters = () => {
   const {
     presenters: { data: presenters },
   } = useDb();
 
+  const { setPresenterFilters } = useContext(FiltersContext);
+
   const handleChange = useCallback(
     (options: MultiValue<Option>) => {
-      onChange(options.map(({ value }) => value));
+      setPresenterFilters(options.map(({ value }) => value));
     },
-    [onChange]
+    [setPresenterFilters]
   );
 
   const options = useMemo(() => {

--- a/src/js/filters/PresenterFilters.tsx
+++ b/src/js/filters/PresenterFilters.tsx
@@ -94,7 +94,7 @@ export const PresenterFilters = ({ onChange }: PresenterFiltersProps) => {
   }, [presenters]);
 
   return (
-    <FilterSection label="Presenter filterss:">
+    <FilterSection label="Presenter filters:">
       <Select
         theme={customTheme}
         styles={styles}

--- a/src/js/filters/PresenterFilters.tsx
+++ b/src/js/filters/PresenterFilters.tsx
@@ -1,127 +1,16 @@
-import styled from 'styled-components';
 import { useCallback, useMemo } from 'react';
 import Select, { MultiValue, Theme, StylesConfig } from 'react-select';
-import {
-  FilterLabels,
-  Option,
-  Presenter,
-  PresenterFiltersProps,
-  SearchField,
-  SearchFiltersProps,
-  SelectedOption,
-} from './types';
-import { useDb } from './dbHooks';
-import { bold } from './styleUtils';
-import { formatName } from './utils';
-import { Colors, hosts } from './constants';
-
-export const FilterBar = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  flex-wrap: wrap;
-  margin: 1.8rem 3vw 0 0;
-
-  @media (max-width: 900px) {
-    margin: 1.8rem 4.5vw 0 0;
-  }
-
-  @media (max-width: 650px) {
-    margin: 1.8rem 6vw 0 0;
-  }
-
-  @media (max-width: 480px) {
-    flex-direction: column;
-    align-items: stretch;
-  }
-`;
-
-const FilterSection = styled.div`
-  display: flex;
-  flex-direction: column;
-  flex-grow: 1;
-  margin: 0 0 1.8rem 3vw;
-
-  @media (max-width: 900px) {
-    margin: 0 0 1.8rem 4.5vw;
-  }
-
-  @media (max-width: 650px) {
-    margin: 0 0 1.8rem 6vw;
-  }
-
-  @media (max-width: 420px) {
-    flex-direction: column;
-    align-items: stretch;
-  }
-`;
-
-const FilterSectionLabel = styled.span`
-  margin: 0 1rem 0.6rem 0;
-  ${bold}
-`;
-
-const SearchFilterWrapper = styled.div`
-  display: flex;
-  flex-grow: 1;
-  flex-wrap: wrap;
-
-  label {
-    margin-right: 1.6rem;
-    display: flex;
-    align-items: center;
-    cursor: pointer;
-    white-space: nowrap;
-  }
-
-  input {
-    margin-left: 0;
-    margin-right: 0.3rem;
-    height: 1.2rem;
-    width: 1.2rem;
-    cursor: pointer;
-  }
-`;
-
-const filterLabels: FilterLabels = {
-  description: 'description',
-  episode: 'episode number',
-  title: 'title',
-  words: 'transcript',
-};
+import { Option, Presenter, PresenterFiltersProps } from '../types';
+import { useDb } from '../dbHooks';
+import { formatName } from '../utils';
+import { Colors, hosts } from '../constants';
+import { FilterSection } from './FilterSection';
 
 const noOneFound = () => 'No one found';
 
 type PresenterType = 'host' | 'qiElf' | 'guest';
 
 type GroupedPresenterOptions = Record<PresenterType, Presenter[]>;
-
-export const SearchFilters = ({ selected, onToggle }: SearchFiltersProps) => {
-  const handleToggle = useCallback(
-    ({ target }: { target: SelectedOption }) => {
-      onToggle(target);
-    },
-    [onToggle]
-  );
-  return (
-    <FilterSection>
-      <FilterSectionLabel>Search filters:</FilterSectionLabel>
-      <SearchFilterWrapper>
-        {Object.entries(selected).map(([name, checked]) => (
-          <label key={name}>
-            <input
-              onChange={handleToggle}
-              type="checkbox"
-              name={name}
-              checked={checked}
-            />
-            {filterLabels[name as SearchField]}
-          </label>
-        ))}
-      </SearchFilterWrapper>
-    </FilterSection>
-  );
-};
 
 const sortByLabel = (a: Option, b: Option) =>
   a.label.toLocaleLowerCase().localeCompare(b.label.toLowerCase());
@@ -205,8 +94,7 @@ export const PresenterFilters = ({ onChange }: PresenterFiltersProps) => {
   }, [presenters]);
 
   return (
-    <FilterSection>
-      <FilterSectionLabel>Presenter filters:</FilterSectionLabel>
+    <FilterSection label="Presenter filterss:">
       <Select
         theme={customTheme}
         styles={styles}

--- a/src/js/filters/SearchFilters.tsx
+++ b/src/js/filters/SearchFilters.tsx
@@ -1,0 +1,64 @@
+import { useCallback } from 'react';
+import styled from 'styled-components';
+import {
+  FilterLabels,
+  SearchField,
+  SearchFiltersProps,
+  SelectedOption,
+} from '../types';
+import { FilterSection } from './FilterSection';
+
+export const SearchFilterWrapper = styled.div`
+  display: flex;
+  flex-grow: 1;
+  flex-wrap: wrap;
+
+  label {
+    margin-right: 1.6rem;
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+
+  input {
+    margin-left: 0;
+    margin-right: 0.3rem;
+    height: 1.2rem;
+    width: 1.2rem;
+    cursor: pointer;
+  }
+`;
+
+const filterLabels: FilterLabels = {
+  description: 'description',
+  episode: 'episode number',
+  title: 'title',
+  words: 'transcript',
+};
+
+export const SearchFilters = ({ selected, onToggle }: SearchFiltersProps) => {
+  const handleToggle = useCallback(
+    ({ target }: { target: SelectedOption }) => {
+      onToggle(target);
+    },
+    [onToggle]
+  );
+  return (
+    <FilterSection label="Search filters:">
+      <SearchFilterWrapper>
+        {Object.entries(selected).map(([name, checked]) => (
+          <label key={name}>
+            <input
+              onChange={handleToggle}
+              type="checkbox"
+              name={name}
+              checked={checked}
+            />
+            {filterLabels[name as SearchField]}
+          </label>
+        ))}
+      </SearchFilterWrapper>
+    </FilterSection>
+  );
+};

--- a/src/js/filters/SearchFilters.tsx
+++ b/src/js/filters/SearchFilters.tsx
@@ -31,9 +31,9 @@ export const FilterWrapper = styled.div`
 `;
 
 const filterLabels: SearchFilterLabels = {
-  description: 'description',
   episode: 'episode number',
   title: 'title',
+  description: 'description',
   words: 'transcript',
 };
 
@@ -47,15 +47,15 @@ export const SearchFilters = ({ selected, onToggle }: SearchFiltersProps) => {
   return (
     <FilterSection label="Search filters:">
       <FilterWrapper>
-        {Object.entries(selected).map(([name, checked]) => (
+        {Object.entries(filterLabels).map(([name, label]) => (
           <label key={name}>
             <input
               onChange={handleToggle}
               type="checkbox"
               name={name}
-              checked={checked}
+              checked={selected[name as SearchField]}
             />
-            {filterLabels[name as SearchField]}
+            {label}
           </label>
         ))}
       </FilterWrapper>

--- a/src/js/filters/SearchFilters.tsx
+++ b/src/js/filters/SearchFilters.tsx
@@ -1,12 +1,8 @@
-import { useCallback } from 'react';
+import { useCallback, useContext } from 'react';
 import styled from 'styled-components';
-import {
-  SearchFilterLabels,
-  SearchField,
-  SearchFiltersProps,
-  SelectedOption,
-} from '../types';
+import { SearchFilterLabels, SearchField, SelectedOption } from '../types';
 import { FilterSection } from './FilterSection';
+import { FiltersContext } from './FiltersContext';
 
 export const FilterWrapper = styled.div`
   display: flex;
@@ -31,18 +27,21 @@ export const FilterWrapper = styled.div`
 `;
 
 const filterLabels: SearchFilterLabels = {
-  episode: 'episode number',
   title: 'title',
   description: 'description',
   words: 'transcript',
+  episode: 'episode number',
 };
 
-export const SearchFilters = ({ selected, onToggle }: SearchFiltersProps) => {
+export const SearchFilters = () => {
+  const { searchFilters, handleSearchFilterToggle } =
+    useContext(FiltersContext);
+
   const handleToggle = useCallback(
-    ({ target }: { target: SelectedOption }) => {
-      onToggle(target);
+    ({ target }: { target: SelectedOption<string> }) => {
+      handleSearchFilterToggle(target as SelectedOption<SearchField>);
     },
-    [onToggle]
+    [handleSearchFilterToggle]
   );
   return (
     <FilterSection label="Search filters:">
@@ -53,7 +52,7 @@ export const SearchFilters = ({ selected, onToggle }: SearchFiltersProps) => {
               onChange={handleToggle}
               type="checkbox"
               name={name}
-              checked={selected[name as SearchField]}
+              checked={searchFilters[name as SearchField]}
             />
             {label}
           </label>

--- a/src/js/index.css
+++ b/src/js/index.css
@@ -42,4 +42,5 @@ h2,
 h3,
 .bold {
   font-family: TTB, 'Courier New', Courier, monospace;
+  font-weight: 600;
 }

--- a/src/js/index.css
+++ b/src/js/index.css
@@ -42,5 +42,4 @@ h2,
 h3,
 .bold {
   font-family: TTB, 'Courier New', Courier, monospace;
-  font-weight: 600;
 }

--- a/src/js/index.css
+++ b/src/js/index.css
@@ -39,7 +39,7 @@ body {
 
 .text {
   font-family: TTE, 'Courier New', Courier, monospace;
-  font-size: 1.1em;
+  font-size: 1em;
 }
 
 h1,

--- a/src/js/index.css
+++ b/src/js/index.css
@@ -37,6 +37,11 @@ body {
   min-height: 100vh;
 }
 
+.text {
+  font-family: TTE, 'Courier New', Courier, monospace;
+  font-size: 1.1em;
+}
+
 h1,
 h2,
 h3,

--- a/src/js/styleUtils.ts
+++ b/src/js/styleUtils.ts
@@ -26,7 +26,3 @@ export const fadeIn = css`
   opacity: 0;
   animation: ${fadeInKeyframes} 151ms ease-in-out forwards;
 `;
-
-export const bold = css`
-  font-family: TTB, 'Courier New', Courier, monospace;
-`;

--- a/src/js/styleUtils.ts
+++ b/src/js/styleUtils.ts
@@ -12,17 +12,3 @@ const spinKeyframes = keyframes`
 export const spin = css`
   animation: ${spinKeyframes} 500ms linear infinite;
 `;
-
-const fadeInKeyframes = keyframes`
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-`;
-
-export const fadeIn = css`
-  opacity: 0;
-  animation: ${fadeInKeyframes} 151ms ease-in-out forwards;
-`;

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -51,25 +51,10 @@ export type Option = {
   value: number;
 };
 
-export type SelectedOption = {
-  name: string;
+export type SelectedOption<T> = {
+  name: T;
   checked: boolean;
 };
-
-export interface EpisodeTypeFiltersProps {
-  selected: EpisodeTypeFiltersState;
-  onToggle: (option: SelectedOption) => void;
-}
-
-export interface SearchFiltersProps {
-  selected: SearchFiltersState;
-  onToggle: (option: SelectedOption) => void;
-}
-
-export interface PresenterFiltersProps {
-  selected: PresentersFilterState;
-  onChange: (presenters: number[]) => void;
-}
 
 export type SelectEpisodeWords = (episode: number) => Promise<Word[]>;
 

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -37,9 +37,14 @@ export type SearchField = 'episode' | 'title' | 'description' | 'words';
 
 export type SearchFiltersState = Record<SearchField, boolean>;
 
+export type EpisodeType = 'live' | 'compilation' | 'wfh' | 'office';
+
+export type EpisodeTypeFiltersState = Record<EpisodeType, boolean>;
+
 export type PresentersFilterState = number[];
 
-export type FilterLabels = Record<SearchField, string>;
+export type SearchFilterLabels = Record<SearchField, string>;
+export type EpisodeTypeFilterLabels = Record<EpisodeType, string>;
 
 export type Option = {
   label: string;
@@ -50,6 +55,11 @@ export type SelectedOption = {
   name: string;
   checked: boolean;
 };
+
+export interface EpisodeTypeFiltersProps {
+  selected: EpisodeTypeFiltersState;
+  onToggle: (option: SelectedOption) => void;
+}
 
 export interface SearchFiltersProps {
   selected: SearchFiltersState;


### PR DESCRIPTION
So the episode list can be filtered by:
 - live episodes
 - compilations
 - wfh episodes
 - QI office episodes

Also made tags clickable to toggle that tag only.

![episode-type-filters](https://github.com/noman-land/transcript.fish/assets/27938023/9182618a-62d4-4824-8151-732ca9d6ac55)
