### PR TITLE
fix: Account for blank summary in RSS feed

### DIFF
--- a/src/python/database.py
+++ b/src/python/database.py
@@ -37,7 +37,7 @@ def make_episode_row(episode, word_count):
         episode['link'], # link
         utils.get_image_url(episode), # image
         int(episode['itunes_duration']), # duration
-        episode['summary'], # description
+        getattr(episode, 'summary', ''), # description
         episode['published'], # pubDate
         episode['id'], # guid
         word_count, # wordCount

--- a/src/python/whisper.py
+++ b/src/python/whisper.py
@@ -15,7 +15,7 @@ model = WhisperModel(
 
 def get_transcription_segments(episode):
     episode_num = utils.get_episode_num(episode)
-    summary = utils.strip_html(episode['summary'])
+    summary = utils.strip_html(getattr(episode, 'summary', ''))
     segments, _ = model.transcribe(
         utils.make_audio_file_path(episode_num),
         word_timestamps=True,


### PR DESCRIPTION
Blank summary crashing the `convert` script.

<img width="1310" alt="image" src="https://github.com/noman-land/transcript.fish/assets/27938023/460f4324-f65b-4214-8258-160de74dc7f5">
