### PR TITLE
fix: Don't wrap text on expand button and make text smaller on small displays

### DIFF
--- a/src/js/EpisodesSearch.tsx
+++ b/src/js/EpisodesSearch.tsx
@@ -35,6 +35,11 @@ const TotalWrapper = styled.div`
     background: none;
     border: 0;
     cursor: pointer;
+    white-space: nowrap;
+
+    @media (max-width: 650px) {
+      font-size: 90%;
+    }
   }
 `;
 


### PR DESCRIPTION
## Before
<img width="442" alt="image" src="https://github.com/noman-land/transcript.fish/assets/27938023/6baa097d-203d-476c-a48a-a50d98a5028f">


## After
<img width="440" alt="image" src="https://github.com/noman-land/transcript.fish/assets/27938023/187a5367-6f8c-4ac4-9246-e95f6080b661">
