### PR TITLE
fix: Embetter filter area styling on smaller displays

### DIFF
--- a/src/js/EpisodesSearch.tsx
+++ b/src/js/EpisodesSearch.tsx
@@ -20,15 +20,21 @@ const Wrapper = styled.div`
 const TotalWrapper = styled.div`
   display: flex;
   justify-content: space-between;
-  margin: 0.6rem 3vw;
+  margin: 0 3vw;
   flex-grow: 1;
 
   @media (max-width: 900px) {
-    margin: 0.6rem 4.5vw;
+    margin: 0 4.5vw;
   }
 
   @media (max-width: 650px) {
-    margin: 0.6rem 6vw;
+    margin: 0 6vw;
+    flex-direction: column;
+  }
+
+  & > * {
+    margin-top: 0.6rem;
+    margin-bottom: 0.6rem;
   }
 
   .expand-all {
@@ -36,9 +42,12 @@ const TotalWrapper = styled.div`
     border: 0;
     cursor: pointer;
     white-space: nowrap;
+    align-self: flex-end;
+    margin-left: 1rem;
 
     @media (max-width: 650px) {
       font-size: 90%;
+      margin-left: 0;
     }
   }
 `;

--- a/src/js/filters/FilterSection.tsx
+++ b/src/js/filters/FilterSection.tsx
@@ -22,6 +22,7 @@ const FilterSectionWrapper = styled.div`
 `;
 
 const FilterSectionLabel = styled.span`
+  text-align: left;
   margin: 0 1rem 0.6rem 0;
 `;
 


### PR DESCRIPTION
Before | After
--- | ---
<img width="251" alt="image" src="https://github.com/noman-land/transcript.fish/assets/27938023/e03a7f64-2108-4a64-be46-00868f14f038"> | <img width="254" alt="image" src="https://github.com/noman-land/transcript.fish/assets/27938023/7101abf9-30d9-4c15-90c9-30ef8f4bbb24">
