### PR TITLE
feat: Add ability to re-transcribe episodes

### DIFF
--- a/src/python/classes.py
+++ b/src/python/classes.py
@@ -16,12 +16,3 @@ class Episode:
         self.description = BeautifulSoup(getattr(episode, 'summary', ''), 'html.parser').get_text()
         self.pub_date: str = episode['published']
         self.guid: str = episode['id']
-        self.presenter1 = None
-        self.presenter2 = None
-        self.presenter3 = None
-        self.presenter4 = None
-        self.presenter5 = None
-        self.venue = None
-        self.live = None
-        self.compilation = None
-        self.event = None

--- a/src/python/classes.py
+++ b/src/python/classes.py
@@ -1,0 +1,27 @@
+import re
+from bs4 import BeautifulSoup
+
+class Episode:
+    def __init__(self, episode):
+        audio, *_ = filter(
+            lambda media: media['medium'] == 'audio',
+            episode['media_content']
+        )
+        self.episode_num = int(episode['itunes_episode'])
+        self.title = re.sub(r'^\d{1,4}:\s', '', episode['title'])
+        self.audio = str(audio['url'])
+        self.link = str(episode['link'])
+        self.image = str(episode['image']['href'])
+        self.duration = int(episode['itunes_duration'])
+        self.description = BeautifulSoup(getattr(episode, 'summary', ''), 'html.parser').get_text()
+        self.pub_date: str = episode['published']
+        self.guid: str = episode['id']
+        self.presenter1 = None
+        self.presenter2 = None
+        self.presenter3 = None
+        self.presenter4 = None
+        self.presenter5 = None
+        self.venue = None
+        self.live = None
+        self.compilation = None
+        self.event = None

--- a/src/python/convert.py
+++ b/src/python/convert.py
@@ -6,11 +6,13 @@ from classes import Episode
 
 def convert(episode_num_to_redo: int | None):
     transcribed = 0
-    for e in fetch.get_rss_episodes(episode_num_to_redo):
-        episode = Episode(e)
+    for episode in fetch.get_rss_episodes(episode_num_to_redo):
         (episode_num, duration) = database.select_episode(episode.episode_num)
-        if episode_num_to_redo or episode.duration < duration:
-            utils.log(episode_num, 'Shorter episode found: Redownloading and retranscribing')
+        new_episode_is_shorter = episode.duration < duration
+        if episode_num_to_redo or new_episode_is_shorter:
+            if new_episode_is_shorter:
+                utils.log(episode_num, 'Shorter episode found')
+            utils.log(episode_num, 'Redownloading and retranscribing')
             utils.delete_audio(episode_num)
             database.delete_transcription(episode_num)
         fetch.download_episode_image(episode)

--- a/src/python/convert.py
+++ b/src/python/convert.py
@@ -1,10 +1,19 @@
 import database
 import fetch
 import whisper
+import utils
 
-def convert():
+def convert(episode_num):
     transcribed = 0
-    for episode in fetch.get_rss_episodes():
+    for episode in fetch.get_rss_episodes(episode_num):
+        (episode_number, duration) = database.select_episode(utils.get_episode_num(episode))
+        new_duration = utils.get_duration(episode)
+
+        if new_duration < duration:
+            utils.log(episode_number, 'Shorter episode found: Redownloading and retranscribing')
+            utils.delete_audio(episode_num)
+            database.delete_transcription(episode_num)
+
         fetch.download_episode_image(episode)
         fetch.download_episode_audio(episode)
         transcribed += whisper.transcribe(episode)

--- a/src/python/convert.py
+++ b/src/python/convert.py
@@ -3,7 +3,7 @@ import fetch
 import whisper
 import utils
 
-def convert(episode_num):
+def convert(episode_num_to_redo: int | None):
     transcribed = 0
     for episode in fetch.get_rss_episodes(episode_num):
         (episode_number, duration) = database.select_episode(utils.get_episode_num(episode))

--- a/src/python/convert.py
+++ b/src/python/convert.py
@@ -2,12 +2,14 @@ import database
 import fetch
 import whisper
 import utils
+from classes import Episode
 
 def convert(episode_num_to_redo: int | None):
     transcribed = 0
-    for episode in fetch.get_rss_episodes(episode_num_to_redo):
-        (episode_num, duration) = database.select_episode(utils.get_episode_num(episode))
-        if episode_num_to_redo or utils.get_duration(episode) < duration:
+    for e in fetch.get_rss_episodes(episode_num_to_redo):
+        episode = Episode(e)
+        (episode_num, duration) = database.select_episode(episode.episode_num)
+        if episode_num_to_redo or episode.duration < duration:
             utils.log(episode_num, 'Shorter episode found: Redownloading and retranscribing')
             utils.delete_audio(episode_num)
             database.delete_transcription(episode_num)

--- a/src/python/convert.py
+++ b/src/python/convert.py
@@ -5,15 +5,12 @@ import utils
 
 def convert(episode_num_to_redo: int | None):
     transcribed = 0
-    for episode in fetch.get_rss_episodes(episode_num):
-        (episode_number, duration) = database.select_episode(utils.get_episode_num(episode))
-        new_duration = utils.get_duration(episode)
-
-        if new_duration < duration:
-            utils.log(episode_number, 'Shorter episode found: Redownloading and retranscribing')
+    for episode in fetch.get_rss_episodes(episode_num_to_redo):
+        (episode_num, duration) = database.select_episode(utils.get_episode_num(episode))
+        if episode_num_to_redo or utils.get_duration(episode) < duration:
+            utils.log(episode_num, 'Shorter episode found: Redownloading and retranscribing')
             utils.delete_audio(episode_num)
             database.delete_transcription(episode_num)
-
         fetch.download_episode_image(episode)
         fetch.download_episode_audio(episode)
         transcribed += whisper.transcribe(episode)

--- a/src/python/database.py
+++ b/src/python/database.py
@@ -33,7 +33,7 @@ def recreate_fts_table():
     ''')
     con.commit()
 
-def make_episode_row(episode, word_count):
+def make_episode_row(episode, word_count: int) -> tuple[int, str, str, str, str, int, str, str, str, int, None, None, None, None, None, None, None, None, None]:
     # "   7: Episode Title" -> "Episode Title"
     # "2361: Episode Title" -> "Episode Title"
     episode_title = re.sub(r'^\d{1,4}:\s', '', episode['title'])
@@ -64,7 +64,7 @@ def vacuum():
     cur.execute('VACUUM;')
     cur = con.commit()
 
-def select_episode(episode_num):
+def select_episode(episode_num: int) -> tuple[int, int]:
     select_word_count_sql = '''
         SELECT
             episode, duration
@@ -76,7 +76,7 @@ def select_episode(episode_num):
     cur = con.cursor()
     return cur.execute(select_word_count_sql, [episode_num]).fetchone()
 
-def select_word_count(episode_num):
+def select_word_count(episode_num: int) -> int:
     select_word_count_sql = '''
         SELECT
             COUNT(*)
@@ -92,7 +92,7 @@ def select_word_count(episode_num):
     word_count = result[0] if result and result[0] > 0 else 0
     return word_count
 
-def delete_transcription(episode_num):
+def delete_transcription(episode_num: int):
     delete_words_sql = '''
         DELETE FROM
             words
@@ -111,11 +111,11 @@ def delete_transcription(episode_num):
     cur.execute(delete_words_sql, [episode_num])
     cur.execute(reset_word_count_sql, [episode_num])
 
-def insert_words(episode_num, words):
+def insert_words(episode_num: int, words):
     cur = con.cursor()
     cur.executemany(f'INSERT INTO words VALUES (?, ?, ?, ?, {episode_num})', words)
 
-def upsert_episode(episode, word_count):
+def upsert_episode(episode, word_count: int):
     upsert_episode_sql = '''
         INSERT INTO
             episodes

--- a/src/python/database.py
+++ b/src/python/database.py
@@ -1,5 +1,5 @@
 import sqlite3
-import utils
+from classes import Episode
 
 db_path = 'db/transcript.db'
 
@@ -32,19 +32,19 @@ def recreate_fts_table():
     ''')
     con.commit()
 
-def make_episode_row(episode, word_count: int) -> tuple[int, str, str, str, str, int, str, str, str, int, None, None, None, None, None, None, None, None, None]:
+def make_episode_row(episode: Episode, word_count: int):
     # "   7: Episode Title" -> "Episode Title"
     # "2361: Episode Title" -> "Episode Title"
     return (
-        utils.get_episode_num(episode), # episode
-        utils.get_title(episode), # title
-        utils.get_audio_url(episode), # audio
-        episode['link'], # link
-        utils.get_image_url(episode), # image
-        utils.get_duration(episode), # duration
-        utils.get_description(episode), # description
-        episode['published'], # pubDate
-        episode['id'], # guid
+        episode.episode_num, # episode
+        episode.title, # title
+        episode.audio, # audio
+        episode.link, # link
+        episode.image, # image
+        episode.duration, # duration
+        episode.description, # description
+        episode.pub_date, # pubDate
+        episode.guid, # guid
         word_count, # wordCount
         None, # presenter1
         None, # presenter2
@@ -113,7 +113,7 @@ def insert_words(episode_num: int, words):
     cur = con.cursor()
     cur.executemany(f'INSERT INTO words VALUES (?, ?, ?, ?, {episode_num})', words)
 
-def upsert_episode(episode, word_count: int):
+def upsert_episode(episode: Episode, word_count: int):
     upsert_episode_sql = '''
         INSERT INTO
             episodes
@@ -124,9 +124,6 @@ def upsert_episode(episode, word_count: int):
         DO UPDATE SET
             audio = excluded.audio,
             duration = excluded.duration,
-            link = excluded.link,
-            pubDate = excluded.pubDate,
-            guid = excluded.guid,
             wordCount = excluded.wordCount
     '''
     episode_row = make_episode_row(episode, word_count)

--- a/src/python/database.py
+++ b/src/python/database.py
@@ -1,4 +1,3 @@
-import re
 import sqlite3
 import utils
 
@@ -36,10 +35,9 @@ def recreate_fts_table():
 def make_episode_row(episode, word_count: int) -> tuple[int, str, str, str, str, int, str, str, str, int, None, None, None, None, None, None, None, None, None]:
     # "   7: Episode Title" -> "Episode Title"
     # "2361: Episode Title" -> "Episode Title"
-    episode_title = re.sub(r'^\d{1,4}:\s', '', episode['title'])
     return (
         utils.get_episode_num(episode), # episode
-        episode_title, # title
+        utils.get_title(episode), # title
         utils.get_audio_url(episode), # audio
         episode['link'], # link
         utils.get_image_url(episode), # image

--- a/src/python/database.py
+++ b/src/python/database.py
@@ -42,7 +42,7 @@ def make_episode_row(episode, word_count: int) -> tuple[int, str, str, str, str,
         episode['link'], # link
         utils.get_image_url(episode), # image
         utils.get_duration(episode), # duration
-        getattr(episode, 'summary', ''), # description
+        utils.get_description(episode), # description
         episode['published'], # pubDate
         episode['id'], # guid
         word_count, # wordCount

--- a/src/python/database.py
+++ b/src/python/database.py
@@ -124,11 +124,11 @@ def upsert_episode(episode, word_count: int):
         ON CONFLICT
             (episode)
         DO UPDATE SET
-            audio = excluded.audio
-            duration = excluded.duration
-            link = excluded.link
-            pubDate = excluded.pubDate
-            guid = excluded.guid
+            audio = excluded.audio,
+            duration = excluded.duration,
+            link = excluded.link,
+            pubDate = excluded.pubDate,
+            guid = excluded.guid,
             wordCount = excluded.wordCount
     '''
     episode_row = make_episode_row(episode, word_count)

--- a/src/python/fetch.py
+++ b/src/python/fetch.py
@@ -11,7 +11,7 @@ def download_episode_audio(episode):
         utils.log(episode_num, 'Already downloaded: audio')
     else:
         utils.create_folder(utils.AUDIO_PATH)
-        utils.log(episode_num, f'Downloading: audio')
+        utils.log(episode_num, 'Downloading: audio')
         urllib.request.urlretrieve(audio_url, audio_path)
 
 opener = urllib.request.build_opener()
@@ -28,23 +28,23 @@ def download_episode_image(episode):
         utils.log(episode_num, 'Already downloaded: image')
     else:
         utils.create_folder(utils.IMAGE_PATH)
-        utils.log(episode_num, f'Downloading: image')
+        utils.log(episode_num, 'Downloading: image')
         urllib.request.install_opener(opener)
         urllib.request.urlretrieve(image_url, image_path)
 
-
-def filter_episodes(episode_num):
-    def filter_fn(e):
-        if episode_num:
-            return utils.is_episode(e) and (utils.get_episode_num(e) == int(episode_num))
-        else:
-            return utils.is_episode(e)
+def make_episode_filter(episode_num: int | None):
+    if episode_num:
+        def filter_fn(episode):
+            return utils.is_episode(episode) and (utils.get_episode_num(episode) == int(episode_num))
+    else:
+        def filter_fn(episode):
+            return utils.is_episode(episode)
     return filter_fn
 
 rss_feed_url = 'https://audioboom.com/channels/2399216.rss'
 
 def get_rss_episodes(episode_num: int | None):
     return filter(
-        filter_episodes(episode_num),
+        make_episode_filter(episode_num),
         reversed(feedparser.parse(rss_feed_url)['entries'])
     )

--- a/src/python/fetch.py
+++ b/src/python/fetch.py
@@ -36,6 +36,7 @@ def get_rss_episodes(episode_num: int | None):
         utils.is_episode,
         reversed(feedparser.parse(rss_feed_url)['entries'])
     )
+
     episodes = map(Episode, episodes_only)
 
     if episode_num:

--- a/src/python/fetch.py
+++ b/src/python/fetch.py
@@ -31,7 +31,7 @@ def download_episode_image(episode: Episode):
 
 rss_feed_url = 'https://audioboom.com/channels/2399216.rss'
 
-def get_rss_episodes(episode_num: int | None):
+def get_rss_episodes(episode_num_to_redo: int | None):
     episodes_only = filter(
         utils.is_episode,
         reversed(feedparser.parse(rss_feed_url)['entries'])
@@ -39,9 +39,7 @@ def get_rss_episodes(episode_num: int | None):
 
     episodes = map(Episode, episodes_only)
 
-    if episode_num:
-        def episode_filter(episode: Episode):
-            return episode.episode_num == int(episode_num)
-        return filter(episode_filter, episodes)
+    if not episode_num_to_redo:
+        return episodes
 
-    return episodes
+    return filter(lambda e: e.episode_num == int(episode_num_to_redo), episodes)

--- a/src/python/fetch.py
+++ b/src/python/fetch.py
@@ -43,7 +43,7 @@ def filter_episodes(episode_num):
 
 rss_feed_url = 'https://audioboom.com/channels/2399216.rss'
 
-def get_rss_episodes(episode_num):
+def get_rss_episodes(episode_num: int | None):
     return filter(
         filter_episodes(episode_num),
         reversed(feedparser.parse(rss_feed_url)['entries'])

--- a/src/python/fetch.py
+++ b/src/python/fetch.py
@@ -2,17 +2,16 @@ from pathlib import Path
 import feedparser
 import urllib.request
 import utils
+from classes import Episode
 
-def download_episode_audio(episode):
-    episode_num = utils.get_episode_num(episode)
-    audio_url = utils.get_audio_url(episode)
-    audio_path = utils.make_audio_file_path(episode_num)
+def download_episode_audio(episode: Episode):
+    audio_path = utils.make_audio_file_path(episode.episode_num)
     if Path(audio_path).exists():
-        utils.log(episode_num, 'Already downloaded: audio')
+        utils.log(episode.episode_num, 'Already downloaded: audio')
     else:
         utils.create_folder(utils.AUDIO_PATH)
-        utils.log(episode_num, 'Downloading: audio')
-        urllib.request.urlretrieve(audio_url, audio_path)
+        utils.log(episode.episode_num, 'Downloading: audio')
+        urllib.request.urlretrieve(episode.audio, audio_path)
 
 opener = urllib.request.build_opener()
 opener.addheaders = [(
@@ -20,31 +19,28 @@ opener.addheaders = [(
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.63 Safari/537.36'
 )]
 
-def download_episode_image(episode):
-    episode_num = utils.get_episode_num(episode)
-    image_url = utils.get_image_url(episode)
-    image_path = utils.make_image_file_path(episode_num, image_url)
+def download_episode_image(episode: Episode):
+    image_path = utils.make_image_file_path(episode.episode_num, episode.image)
     if Path(image_path).exists():
-        utils.log(episode_num, 'Already downloaded: image')
+        utils.log(episode.episode_num, 'Already downloaded: image')
     else:
         utils.create_folder(utils.IMAGE_PATH)
-        utils.log(episode_num, 'Downloading: image')
+        utils.log(episode.episode_num, 'Downloading: image')
         urllib.request.install_opener(opener)
-        urllib.request.urlretrieve(image_url, image_path)
-
-def make_episode_filter(episode_num: int | None):
-    if episode_num:
-        def filter_fn(episode):
-            return utils.is_episode(episode) and (utils.get_episode_num(episode) == int(episode_num))
-    else:
-        def filter_fn(episode):
-            return utils.is_episode(episode)
-    return filter_fn
+        urllib.request.urlretrieve(episode.image, image_path)
 
 rss_feed_url = 'https://audioboom.com/channels/2399216.rss'
 
 def get_rss_episodes(episode_num: int | None):
-    return filter(
-        make_episode_filter(episode_num),
+    episodes_only = filter(
+        utils.is_episode,
         reversed(feedparser.parse(rss_feed_url)['entries'])
     )
+    episodes = map(Episode, episodes_only)
+
+    if episode_num:
+        def episode_filter(episode: Episode):
+            return episode.episode_num == int(episode_num)
+        return filter(episode_filter, episodes)
+
+    return episodes

--- a/src/python/fetch.py
+++ b/src/python/fetch.py
@@ -8,10 +8,10 @@ def download_episode_audio(episode):
     audio_url = utils.get_audio_url(episode)
     audio_path = utils.make_audio_file_path(episode_num)
     if Path(audio_path).exists():
-        utils.log(episode_num, 'Already complete: audio download')
+        utils.log(episode_num, 'Already downloaded: audio')
     else:
         utils.create_folder(utils.AUDIO_PATH)
-        utils.log(episode_num, f'Downloading: audio - {audio_url}')
+        utils.log(episode_num, f'Downloading: audio')
         urllib.request.urlretrieve(audio_url, audio_path)
 
 opener = urllib.request.build_opener()
@@ -25,13 +25,26 @@ def download_episode_image(episode):
     image_url = utils.get_image_url(episode)
     image_path = utils.make_image_file_path(episode_num, image_url)
     if Path(image_path).exists():
-        utils.log(episode_num, 'Already complete: image download')
+        utils.log(episode_num, 'Already downloaded: image')
     else:
         utils.create_folder(utils.IMAGE_PATH)
-        utils.log(episode_num, f'Downloading: image - {image_url}')
+        utils.log(episode_num, f'Downloading: image')
         urllib.request.install_opener(opener)
         urllib.request.urlretrieve(image_url, image_path)
 
+
+def filter_episodes(episode_num):
+    def filter_fn(e):
+        if episode_num:
+            return utils.is_episode(e) and (utils.get_episode_num(e) == int(episode_num))
+        else:
+            return utils.is_episode(e)
+    return filter_fn
+
 rss_feed_url = 'https://audioboom.com/channels/2399216.rss'
-def get_rss_episodes():
-    return filter(lambda e: utils.is_episode(e), reversed(feedparser.parse(rss_feed_url)['entries']))
+
+def get_rss_episodes(episode_num):
+    return filter(
+        filter_episodes(episode_num),
+        reversed(feedparser.parse(rss_feed_url)['entries'])
+    )

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -7,7 +7,7 @@ from convert import convert
 # It will fill in any gaps
 if __name__ == '__main__':
     try:
-        episode_num = sys.argv[1] if len(sys.argv) > 1 else None
+        episode_num = int(sys.argv[1]) if len(sys.argv) > 1 else None
         convert(episode_num)
     except KeyboardInterrupt:
         print('\n[ ⚡️ CTRL + C ⚡️ ] Script interrupted. Cleaning up.')

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -7,7 +7,8 @@ from convert import convert
 # It will fill in any gaps
 if __name__ == '__main__':
     try:
-        convert()
+        episode_num = sys.argv[1] if len(sys.argv) > 1 else None
+        convert(episode_num)
     except KeyboardInterrupt:
         print('\n[ ⚡️ CTRL + C ⚡️ ] Script interrupted. Cleaning up.')
         database.close()

--- a/src/python/utils.py
+++ b/src/python/utils.py
@@ -1,5 +1,4 @@
 import os
-import re
 from datetime import datetime
 from bs4 import BeautifulSoup
 
@@ -38,25 +37,6 @@ def get_episode_num(episode):
 
 def is_episode(episode):
     return True if getattr(episode,'itunes_episode', None) else False
-
-def is_audio(media) -> bool:
-    return media['medium'] == 'audio'
-
-def get_audio_url(episode) -> str:
-    audio, *_ = filter(is_audio, episode['media_content'])
-    return audio['url']
-
-def get_title(episode) -> str:
-    return re.sub(r'^\d{1,4}:\s', '', episode['title'])
-
-def get_image_url(episode) -> str:
-    return episode['image']['href']
-
-def get_duration(episode):
-    return int(episode['itunes_duration'])
-
-def get_description(episode) -> str:
-    return getattr(episode, 'summary', '')
 
 def strip_html(htmlString: str):
     return BeautifulSoup(htmlString, 'html.parser').get_text()

--- a/src/python/utils.py
+++ b/src/python/utils.py
@@ -55,7 +55,7 @@ def get_image_url(episode) -> str:
 def get_duration(episode):
     return int(episode['itunes_duration'])
 
-def get_description(episode):
+def get_description(episode) -> str:
     return getattr(episode, 'summary', '')
 
 def strip_html(htmlString: str):

--- a/src/python/utils.py
+++ b/src/python/utils.py
@@ -5,28 +5,27 @@ from bs4 import BeautifulSoup
 AUDIO_PATH = "audio"
 IMAGE_PATH = "images/episodes"
 
-def log(episode_num, *msg):
+def log(episode_num: int, *msg: str) -> None:
     print(f'-- {now()} [ Episode {episode_num} ]', *msg)
 
 def now():
     return datetime.now().strftime('%H:%M:%S')
 
-def create_folder(folder_path):
+def create_folder(folder_path: str):
     # Check if the folder exists, and if not, create it
     if not os.path.exists(folder_path):
         os.makedirs(folder_path)
         print(f'-- {now()} Created folder {folder_path}')
 
-def make_audio_file_path(episode_num):
+def make_audio_file_path(episode_num: int):
     return f'{AUDIO_PATH}/{episode_num}.mp3'
 
-def make_image_file_path(episode_num, image_url):
+def make_image_file_path(episode_num: int, image_url: str):
     file_extension = os.path.splitext(image_url)[1]
     # file extension includes dot at the beginning
     return f'{IMAGE_PATH}/{episode_num}{file_extension}'
 
-def delete_audio(episode_num):
-    make_audio_file_path(episode_num)
+def delete_audio(episode_num: int):
     try:
         os.remove(make_audio_file_path(episode_num))
         log(episode_num, "Deleted: audio")
@@ -39,18 +38,18 @@ def get_episode_num(episode):
 def is_episode(episode):
     return True if getattr(episode,'itunes_episode', None) else False
 
-def is_audio(media):
+def is_audio(media) -> bool:
     return media['medium'] == 'audio'
 
-def get_audio_url(episode):
+def get_audio_url(episode) -> str:
     audio, *_ = filter(is_audio, episode['media_content'])
     return audio['url']
 
-def get_image_url(episode):
+def get_image_url(episode) -> str:
     return episode['image']['href']
 
 def get_duration(episode):
     return int(episode['itunes_duration'])
 
-def strip_html(htmlString):
+def strip_html(htmlString: str):
     return BeautifulSoup(htmlString, 'html.parser').get_text()

--- a/src/python/utils.py
+++ b/src/python/utils.py
@@ -25,6 +25,14 @@ def make_image_file_path(episode_num, image_url):
     # file extension includes dot at the beginning
     return f'{IMAGE_PATH}/{episode_num}{file_extension}'
 
+def delete_audio(episode_num):
+    make_audio_file_path(episode_num)
+    try:
+        os.remove(make_audio_file_path(episode_num))
+        log(episode_num, "Deleted: audio")
+    except OSError as e:
+        log(episode_num, "Error deleting %s: %s" % (e.filename, e.strerror))
+
 def get_episode_num(episode):
     return int(episode['itunes_episode'])
 
@@ -40,6 +48,9 @@ def get_audio_url(episode):
 
 def get_image_url(episode):
     return episode['image']['href']
+
+def get_duration(episode):
+    return int(episode['itunes_duration'])
 
 def strip_html(htmlString):
     return BeautifulSoup(htmlString, 'html.parser').get_text()

--- a/src/python/utils.py
+++ b/src/python/utils.py
@@ -1,5 +1,6 @@
-from datetime import datetime
 import os
+import re
+from datetime import datetime
 from bs4 import BeautifulSoup
 
 AUDIO_PATH = "audio"
@@ -44,6 +45,9 @@ def is_audio(media) -> bool:
 def get_audio_url(episode) -> str:
     audio, *_ = filter(is_audio, episode['media_content'])
     return audio['url']
+
+def get_title(episode) -> str:
+    return re.sub(r'^\d{1,4}:\s', '', episode['title'])
 
 def get_image_url(episode) -> str:
     return episode['image']['href']

--- a/src/python/utils.py
+++ b/src/python/utils.py
@@ -55,5 +55,8 @@ def get_image_url(episode) -> str:
 def get_duration(episode):
     return int(episode['itunes_duration'])
 
+def get_description(episode):
+    return getattr(episode, 'summary', '')
+
 def strip_html(htmlString: str):
     return BeautifulSoup(htmlString, 'html.parser').get_text()

--- a/src/python/whisper.py
+++ b/src/python/whisper.py
@@ -38,7 +38,7 @@ def transcribe(episode):
         word_count += len(words)
         database.insert_words(episode_num, words)
         segments_transcribed += 1
-        utils.log(episode_num, f'Completed: {segments_transcribed} segments and {word_count} words')
+        utils.log(episode_num, f'Transcribed: {segments_transcribed} segments and {word_count} words')
     database.upsert_episode(episode, word_count)
     database.commit()
     utils.log(episode_num, f'Completed: transcription: {word_count} words')

--- a/src/python/whisper.py
+++ b/src/python/whisper.py
@@ -1,6 +1,7 @@
 from faster_whisper import WhisperModel
 import database
 import utils
+from classes import Episode
 
 model_size = 'large-v2'
 
@@ -13,33 +14,30 @@ model = WhisperModel(
     cpu_threads=8
 )
 
-def get_transcription_segments(episode):
-    episode_num = utils.get_episode_num(episode)
-    summary = utils.strip_html(getattr(episode, 'summary', ''))
+def get_transcription_segments(episode: Episode):
     segments, _ = model.transcribe(
-        utils.make_audio_file_path(episode_num),
+        utils.make_audio_file_path(episode.episode_num),
         word_timestamps=True,
-        initial_prompt=f'This is episode number {episode_num} of No Such Thing As A Fish, a weekly podcast in which QI researchers Dan Schreiber, James Harkin, Anna Ptaszynski, and Andrew Hunter Murray share the most bizarre, extraordinary and hilarious facts they have discovered over the last seven days. Here is the summary of this week\'s episode.\n\n"{summary}"\n\n'
+        initial_prompt=f'This is episode number {episode.episode_num} of No Such Thing As A Fish, a weekly podcast in which QI researchers Dan Schreiber, James Harkin, Anna Ptaszynski, and Andrew Hunter Murray share the most bizarre, extraordinary and hilarious facts they have discovered over the last seven days. Here is the summary of this week\'s episode.\n\n"{episode.description}"\n\n'
     )
     return segments
 
-def transcribe(episode):
-    episode_num = utils.get_episode_num(episode)
-    saved_word_count = database.select_word_count(episode_num)
+def transcribe(episode: Episode):
+    saved_word_count = database.select_word_count(episode.episode_num)
     if saved_word_count > 0:
-        utils.log(episode_num, f'Already complete: transcription: {saved_word_count} words')
+        utils.log(episode.episode_num, f'Already complete: transcription: {saved_word_count} words')
         return 0
 
-    utils.log(episode_num, 'Starting: transcription')
+    utils.log(episode.episode_num, 'Starting: transcription')
     word_count = 0
     segments_transcribed = 0
     for segment in get_transcription_segments(episode):
         words = getattr(segment, 'words', [])
         word_count += len(words)
-        database.insert_words(episode_num, words)
+        database.insert_words(episode.episode_num, words)
         segments_transcribed += 1
-        utils.log(episode_num, f'Transcribed: {segments_transcribed} segments and {word_count} words')
+        utils.log(episode.episode_num, f'Transcribed: {segments_transcribed} segments and {word_count} words')
     database.upsert_episode(episode, word_count)
     database.commit()
-    utils.log(episode_num, f'Completed: transcription: {word_count} words')
+    utils.log(episode.episode_num, f'Completed: transcription: {word_count} words')
     return 1

--- a/src/python/whisper.py
+++ b/src/python/whisper.py
@@ -33,13 +33,12 @@ def transcribe(episode):
     utils.log(episode_num, 'Starting: transcription')
     word_count = 0
     segments_transcribed = 0
-    segments = get_transcription_segments(episode)
-    for segment in segments:
+    for segment in get_transcription_segments(episode):
         words = getattr(segment, 'words', [])
         word_count += len(words)
         database.insert_words(episode_num, words)
         segments_transcribed += 1
-        utils.log(episode_num, f'Completed {segments_transcribed} segments and {word_count} words')
+        utils.log(episode_num, f'Completed: {segments_transcribed} segments and {word_count} words')
     database.upsert_episode(episode, word_count)
     database.commit()
     utils.log(episode_num, f'Completed: transcription: {word_count} words')


### PR DESCRIPTION
This PR adds two primary features to the transcription script.

1. Ability to re-transcribe a single episode: `npm run convert 510` (Resolves: https://github.com/noman-land/transcript.fish/issues/69)
2. The default `npm convert` script now checks if prior episodes have shorter audio, which means their ads were removed. If so, it re-downloads them, and re-transcribes them