### PR TITLE
Feat: Add page number and searchTerm to url param

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "react-error-boundary": "^4.0.10",
+        "react-router-dom": "^6.23.1",
         "react-select": "^5.7.7",
         "sql.js-httpvfs": "^0.8.12",
         "sqlite3": "^5.1.6",
@@ -1068,6 +1069,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.16.1.tgz",
+      "integrity": "sha512-es2g3dq6Nb07iFxGk5GuHN20RwBZOsuDQN7izWIisUcv9r+d2C5jQxqmgkdebXgReWfiyUabcki6Fg77mSNrig==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@swc/core": {
@@ -5031,6 +5040,36 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-router": {
+      "version": "6.23.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.23.1.tgz",
+      "integrity": "sha512-fzcOaRF69uvqbbM7OhvQyBTFDVrrGlsFdS3AL+1KfIBtGETibHzi3FkoTRyiDJnWNc2VxrfvR+657ROHjaNjqQ==",
+      "dependencies": {
+        "@remix-run/router": "1.16.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.23.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.23.1.tgz",
+      "integrity": "sha512-utP+K+aSTtEdbWpC+4gxhdlPFwuEfDKq8ZrPFU65bbRJY+l706qjR7yaidBpo3MSeA/fzwbXWbKBI6ftOnP3OQ==",
+      "dependencies": {
+        "@remix-run/router": "1.16.1",
+        "react-router": "6.23.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
     },
     "node_modules/react-select": {
       "version": "5.8.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "license": "MIT",
   "dependencies": {
     "react-error-boundary": "^4.0.10",
+    "react-router-dom": "^6.23.1",
     "react-select": "^5.7.7",
     "sql.js-httpvfs": "^0.8.12",
     "sqlite3": "^5.1.6",

--- a/src/js/App.tsx
+++ b/src/js/App.tsx
@@ -64,9 +64,9 @@ export const App = () => {
               <h1>transcript.fish</h1>
               <UnderConstructionBanner />
               <img
-              className="logo"
-              src={mediaUrl.images('logo-transparent.png')}
-            />
+                className="logo"
+                src={mediaUrl.images('logo-transparent.png')}
+              />
               <ErrorBoundary FallbackComponent={EpisodeSearchFallback}>
                 <FiltersContextProvider>
                   <Routes>

--- a/src/js/App.tsx
+++ b/src/js/App.tsx
@@ -7,6 +7,7 @@ import { mediaUrl } from './utils';
 import { AudioContextWrapper } from './audio/AudioContext';
 import { Colors } from './constants';
 import { FiltersContextProvider } from './filters/FiltersContext';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 
 const Wrapper = styled.div`
   display: flex;
@@ -52,26 +53,30 @@ export const App = () => {
   return (
     <Wrapper>
       <AudioContextWrapper>
-        <>
-          <header>
-            <a href="https://github.com/noman-land/transcript.fish">
-              <img width={32} src={mediaUrl.images('github-logo.png')} />
-            </a>
-          </header>
-          <div className="app-body">
-            <h1>transcript.fish</h1>
-            <UnderConstructionBanner />
-            <img
+        <Router>
+          <>
+            <header>
+              <a href="https://github.com/noman-land/transcript.fish">
+                <img width={32} src={mediaUrl.images('github-logo.png')} />
+              </a>
+            </header>
+            <div className="app-body">
+              <h1>transcript.fish</h1>
+              <UnderConstructionBanner />
+              <img
               className="logo"
               src={mediaUrl.images('logo-transparent.png')}
             />
-            <ErrorBoundary FallbackComponent={EpisodeSearchFallback}>
-              <FiltersContextProvider>
-                <EpisodeSearch />
-              </FiltersContextProvider>
-            </ErrorBoundary>
-          </div>
-        </>
+              <ErrorBoundary FallbackComponent={EpisodeSearchFallback}>
+                <FiltersContextProvider>
+                  <Routes>
+                    <Route path="/" element={<EpisodeSearch />} />
+                  </Routes>
+                </FiltersContextProvider>
+              </ErrorBoundary>
+            </div>
+          </>
+        </Router>
       </AudioContextWrapper>
     </Wrapper>
   );

--- a/src/js/EpisodesSearch.tsx
+++ b/src/js/EpisodesSearch.tsx
@@ -94,6 +94,12 @@ export const EpisodeSearch = () => {
 
   useEffect(() => {
     if (isMounted) {
+      search(searchTerm, searchFilters);
+    }
+  }, [search, searchTerm, searchFilters, isMounted]);
+
+  useEffect(() => {
+    if (isMounted) {
       setPage(0);
     } else {
       setIsMounted(true);
@@ -103,20 +109,8 @@ export const EpisodeSearch = () => {
     presenterFilters,
     searchTerm,
     searchFilters,
-    isMounted,
-  ]);
-
-  useEffect(() => {
-    if (isMounted) {
-      search(searchTerm, searchFilters);
-    }
-  }, [
-    episodeTypeFilters,
-    presenterFilters,
-    searchTerm,
-    searchFilters,
     venueFilters,
-    isMounted
+    isMounted,
   ]);
 
   const handleSubmit = useCallback((e: FormEvent) => {


### PR DESCRIPTION
Store search and page number in URL so links to specific searches can be shared.

Could be done without react-router-dom if new packages aren't wanted, this was just the most efficient way to do it.

Updates the SearchBar input placeholder to the search term from the query, I also considered changing the actual value of the input so the user can also edit the search from a URL without retyping the whole text but it would require adding state and changing how the submission works. Not too hard, just wasn't sure if it was worth it.

I think adding filters to URL might be a bit overkill?

Happy to hear any feedback or thoughts :) 